### PR TITLE
Updating to support Lua 5.1

### DIFF
--- a/makefile
+++ b/makefile
@@ -40,8 +40,9 @@ lpeglabel.so: $(FILES)
 
 $(FILES): makefile
 
-test: test.lua re.lua lpeglabel.so
-	./test.lua
+test: test.lua relabel.lua lpeglabel.so
+	lua test.lua
+	lua testlabel.lua
 
 clean:
 	rm -f $(FILES) lpeglabel.so

--- a/relabel.lua
+++ b/relabel.lua
@@ -3,7 +3,7 @@
 -- imported functions and modules
 local tonumber, type, print, error = tonumber, type, print, error
 local setmetatable = setmetatable
-local unpack = table.unpack
+local unpack = table.unpack or unpack
 local m = require"lpeglabel"
 
 -- 'm' will be used to parse expressions, and 'mm' will be used to

--- a/rockspecs/lpeglabel-0.12.2-1.rockspec
+++ b/rockspecs/lpeglabel-0.12.2-1.rockspec
@@ -1,0 +1,32 @@
+package = "LPegLabel"
+version = "0.12.2-1"
+source = {
+   url = "https://github.com/sqmedeiros/lpeglabel/archive/v0.12.2.tar.gz",
+   tag = "v0.12.2",
+   dir = "lpeglabel-0.12.2",
+}
+description = {
+   summary = "Parsing Expression Grammars For Lua with Labeled Failures",
+   detailed = [[
+     LPegLabel is a conservative extension of the LPeg library that provides
+     an implementation of Parsing Expression Grammars (PEGs) with labeled failures. 
+     Labels can be used to signal different kinds of erros and to specify which
+     alternative in a labeled ordered choice should handle a given label.
+     Labels can also be combined with the standard patterns of LPeg.  
+   ]],
+   homepage = "https://github.com/sqmedeiros/lpeglabel/",
+   maintainer = "Sergio Medeiros <sqmedeiros@gmail.com>",
+   license = "MIT/X11"
+}
+dependencies = {
+   "lua >= 5.2",
+}
+build = {
+   type = "builtin",
+   modules = {
+      lpeglabel = {
+         "lpcap.c", "lpcode.c", "lpprint.c", "lptree.c", "lpvm.c"
+      },
+      relabel = "relabel.lua"
+   }
+}

--- a/rockspecs/lpeglabel-0.12.2-2.rockspec
+++ b/rockspecs/lpeglabel-0.12.2-2.rockspec
@@ -1,0 +1,32 @@
+package = "LPegLabel"
+version = "0.12.2-2"
+source = {
+   url = "https://github.com/sqmedeiros/lpeglabel/archive/v0.12.2-2.tar.gz",
+   tag = "v0.12.2-2",
+   dir = "lpeglabel-0.12.2-2",
+}
+description = {
+   summary = "Parsing Expression Grammars For Lua with Labeled Failures",
+   detailed = [[
+     LPegLabel is a conservative extension of the LPeg library that provides
+     an implementation of Parsing Expression Grammars (PEGs) with labeled failures. 
+     Labels can be used to signal different kinds of erros and to specify which
+     alternative in a labeled ordered choice should handle a given label.
+     Labels can also be combined with the standard patterns of LPeg.  
+   ]],
+   homepage = "https://github.com/sqmedeiros/lpeglabel/",
+   maintainer = "Sergio Medeiros <sqmedeiros@gmail.com>",
+   license = "MIT/X11"
+}
+dependencies = {
+   "lua >= 5.1",
+}
+build = {
+   type = "builtin",
+   modules = {
+      lpeglabel = {
+         "lpcap.c", "lpcode.c", "lpprint.c", "lptree.c", "lpvm.c"
+      },
+      relabel = "relabel.lua"
+   }
+}


### PR DESCRIPTION
This pull request allows LPegLabel to work under Lua 5.1 by using `unpack` from the basic library of Lua (`unpack` was moved into the table library in Lua 5.2). 
