### PR TITLE
Fix name clashing issues with LPEG

### DIFF
--- a/lpcap.h
+++ b/lpcap.h
@@ -48,9 +48,9 @@ typedef struct CapState {
 } CapState;
 
 
-int runtimecap (CapState *cs, Capture *close, const char *s, int *rem);
-int getcaptures (lua_State *L, const char *s, const char *r, int ptop);
-int finddyncap (Capture *cap, Capture *last);
+LUAI_FUNC int runtimecap (CapState *cs, Capture *close, const char *s, int *rem);
+LUAI_FUNC int getcaptures (lua_State *L, const char *s, const char *r, int ptop);
+LUAI_FUNC int finddyncap (Capture *cap, Capture *last);
 
 #endif
 

--- a/lpcode.h
+++ b/lpcode.h
@@ -11,14 +11,14 @@
 #include "lptree.h"
 #include "lpvm.h"
 
-int tocharset (TTree *tree, Charset *cs);
-int checkaux (TTree *tree, int pred);
-int fixedlen (TTree *tree);
-int hascaptures (TTree *tree);
-int lp_gc (lua_State *L);
-Instruction *compile (lua_State *L, Pattern *p);
-void realloccode (lua_State *L, Pattern *p, int nsize);
-int sizei (const Instruction *i);
+LUAI_FUNC int tocharset (TTree *tree, Charset *cs);
+LUAI_FUNC int checkaux (TTree *tree, int pred);
+LUAI_FUNC int fixedlen (TTree *tree);
+LUAI_FUNC int hascaptures (TTree *tree);
+LUAI_FUNC int lp_gc (lua_State *L);
+LUAI_FUNC Instruction *compile (lua_State *L, Pattern *p);
+LUAI_FUNC void realloccode (lua_State *L, Pattern *p, int nsize);
+LUAI_FUNC int sizei (const Instruction *i);
 
 
 #define PEnullable      0

--- a/lpprint.h
+++ b/lpprint.h
@@ -13,12 +13,12 @@
 
 #if defined(LPEG_DEBUG)
 
-void printpatt (Instruction *p, int n);
-void printtree (TTree *tree, int ident);
-void printktable (lua_State *L, int idx);
-void printcharset (const byte *st);
-void printcaplist (Capture *cap, Capture *limit);
-void printinst (const Instruction *op, const Instruction *p);
+LUAI_FUNC void printpatt (Instruction *p, int n);
+LUAI_FUNC void printtree (TTree *tree, int ident);
+LUAI_FUNC void printktable (lua_State *L, int idx);
+LUAI_FUNC void printcharset (const byte *st);
+LUAI_FUNC void printcaplist (Capture *cap, Capture *limit);
+LUAI_FUNC void printinst (const Instruction *op, const Instruction *p);
 
 #else
 

--- a/lptree.h
+++ b/lptree.h
@@ -73,7 +73,7 @@ typedef struct Pattern {
 
 
 /* number of children for each tree */
-extern const byte numsiblings[];
+LUAI_FUNC const byte numsiblings[];
 
 /* access to children */
 #define sib1(t)         ((t) + 1)

--- a/lptypes.h
+++ b/lptypes.h
@@ -18,8 +18,8 @@
 #define VERSION         "1.6.0"
 
 
-#define PATTERN_T	"lpeg-pattern"
-#define MAXSTACKIDX	"lpeg-maxstack"
+#define PATTERN_T	"lpeglabel-pattern"
+#define MAXSTACKIDX	"lpeglabel-maxstack"
 
 
 /*
@@ -35,7 +35,7 @@
 #define lua_rawlen		lua_objlen
 
 #define luaL_setfuncs(L,f,n)	luaL_register(L,NULL,f)
-#define luaL_newlib(L,f)	luaL_register(L,"lpeg",f)
+#define luaL_newlib(L,f)	luaL_register(L,"lpeglabel",f)
 
 typedef size_t lua_Unsigned;
 

--- a/lpvm.h
+++ b/lpvm.h
@@ -58,8 +58,8 @@ typedef union Instruction {
 #define utf_to(inst)	(((inst)->i.key << 8) | (inst)->i.aux)
 
 
-void printpatt (Instruction *p, int n);
-const char *match (lua_State *L, const char *o, const char *s, const char *e,
+LUAI_FUNC void printpatt (Instruction *p, int n);
+LUAI_FUNC const char *match (lua_State *L, const char *o, const char *s, const char *e,
                    Instruction *op, Capture *capture, int ptop, short *labelf, const char **sfail); /* labeled failure */
 
 #endif


### PR DESCRIPTION
I was using lpeglabel with some other module from LuaRocks that used lpeg (not lpeglabel) and I was getting some odd crashes and issues, then I found out that my compiler was confusing exported symbols from lpeg and lpeglabel. The fix was using LUAI_FUNC in lpeglabel internal functions to make it not export internal symbols. After fixing this I was having issues with PATTERN_T using the same table as lpeg leading to other crashes and renaming it to solved the issue. With the changes from this commit I am able to use lpeg and lpeglabel in the same application without crashes or issues.