### PR TITLE
Fix issue #27

### DIFF
--- a/lpcode.c
+++ b/lpcode.c
@@ -535,16 +535,18 @@ static int addoffsetinst (CompileState *compst, Opcode op) {
 
 /* labeled failure */
 static void codethrow (CompileState *compst, TTree *throw) {
-  int recov, aux;
+  int recov, aux, n;
   if (throw->u.ps != 0) {
     recov = addoffsetinst(compst, IThrowRec);
     assert(sib1(sib2(throw))->tag == TXInfo);
+    n = sib1(sib2(throw))->u.n;
   } else {
     recov = addinstruction(compst, IThrow, 0);
+    n = -1;
   }
   aux = nextinstruction(compst);
   getinstr(compst, aux).i.key = throw->key; /* next instruction keeps only rule name */
-  getinstr(compst, recov).i.key = sib1(sib2(throw))->u.n;  /* rule number */
+  getinstr(compst, recov).i.key = n;  /* rule number */
 }
 /* labeled failure */
 


### PR DESCRIPTION
This is my attempt to fix the buffer overflow.  My guess was that `sib1(sib2(throw))` should be only read when `throw->u.ps != 0` however I don't know what value to use in the else for the rule number, I've guessed -1. I made this without knowing how lpeg internals works, please ignore this if I'm wrong and do the proper fix.