### PR TITLE
change prefix of source files from 'lp' to 'lpl'

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,5 +486,5 @@ its initial rule.
 
 In case your grammar has many regular and recovery rules,
 you may get an error message such as grammar: <em>has too many rules</em>.
-In this case, we need to change *MAXRULES* in `lptypes.h`.
+In this case, we need to change *MAXRULES* in `lpltypes.h`.
   

--- a/lplcap.c
+++ b/lplcap.c
@@ -1,13 +1,13 @@
 /*
-** $Id: lpcap.c $
+** $Id: lplcap.c $
 ** Copyright 2007, Lua.org & PUC-Rio  (see 'lpeg.html' for license)
 */
 
 #include "lua.h"
 #include "lauxlib.h"
 
-#include "lpcap.h"
-#include "lptypes.h"
+#include "lplcap.h"
+#include "lpltypes.h"
 
 
 #define captype(cap)	((cap)->kind)

--- a/lplcap.h
+++ b/lplcap.h
@@ -1,12 +1,12 @@
 /*
-** $Id: lpcap.h $
+** $Id: lplcap.h $
 */
 
-#if !defined(lpcap_h)
-#define lpcap_h
+#if !defined(lplcap_h)
+#define lplcap_h
 
 
-#include "lptypes.h"
+#include "lpltypes.h"
 
 
 /* kinds of captures */

--- a/lplcode.c
+++ b/lplcode.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lpcode.c $
+** $Id: lplcode.c $
 ** Copyright 2007, Lua.org & PUC-Rio  (see 'lpeg.html' for license)
 */
 
@@ -9,8 +9,8 @@
 #include "lua.h"
 #include "lauxlib.h"
 
-#include "lptypes.h"
-#include "lpcode.h"
+#include "lpltypes.h"
+#include "lplcode.h"
 
 
 /* signals a "no-instruction */

--- a/lplcode.h
+++ b/lplcode.h
@@ -1,15 +1,15 @@
 /*
-** $Id: lpcode.h $
+** $Id: lplcode.h $
 */
 
-#if !defined(lpcode_h)
-#define lpcode_h
+#if !defined(lplcode_h)
+#define lplcode_h
 
 #include "lua.h"
 
-#include "lptypes.h"
-#include "lptree.h"
-#include "lpvm.h"
+#include "lpltypes.h"
+#include "lpltree.h"
+#include "lplvm.h"
 
 LUAI_FUNC int tocharset (TTree *tree, Charset *cs);
 LUAI_FUNC int checkaux (TTree *tree, int pred);

--- a/lplprint.c
+++ b/lplprint.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lpprint.c $
+** $Id: lplprint.c $
 ** Copyright 2007, Lua.org & PUC-Rio  (see 'lpeg.html' for license)
 */
 
@@ -8,9 +8,9 @@
 #include <stdio.h>
 
 
-#include "lptypes.h"
-#include "lpprint.h"
-#include "lpcode.h"
+#include "lpltypes.h"
+#include "lplprint.h"
+#include "lplcode.h"
 
 
 #if defined(LPEG_DEBUG)

--- a/lplprint.h
+++ b/lplprint.h
@@ -1,14 +1,14 @@
 /*
-** $Id: lpprint.h $
+** $Id: lplprint.h $
 */
 
 
-#if !defined(lpprint_h)
-#define lpprint_h
+#if !defined(lplprint_h)
+#define lplprint_h
 
 
-#include "lptree.h"
-#include "lpvm.h"
+#include "lpltree.h"
+#include "lplvm.h"
 
 
 #if defined(LPEG_DEBUG)

--- a/lpltree.c
+++ b/lpltree.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lptree.c $
+** $Id: lpltree.c $
 ** Copyright 2013, Lua.org & PUC-Rio  (see 'lpeg.html' for license)
 */
 
@@ -11,11 +11,11 @@
 #include "lua.h"
 #include "lauxlib.h"
 
-#include "lptypes.h"
-#include "lpcap.h"
-#include "lpcode.h"
-#include "lpprint.h"
-#include "lptree.h"
+#include "lpltypes.h"
+#include "lplcap.h"
+#include "lplcode.h"
+#include "lplprint.h"
+#include "lpltree.h"
 
 
 /* number of siblings for each tree */

--- a/lpltree.h
+++ b/lpltree.h
@@ -1,12 +1,12 @@
 /*  
-** $Id: lptree.h $
+** $Id: lpltree.h $
 */
 
-#if !defined(lptree_h)
-#define lptree_h
+#if !defined(lpltree_h)
+#define lpltree_h
 
 
-#include "lptypes.h" 
+#include "lpltypes.h"
 
 
 /*

--- a/lpltypes.h
+++ b/lpltypes.h
@@ -1,12 +1,12 @@
 /*
-** $Id: lptypes.h $
+** $Id: lpltypes.h $
 ** LPeg - PEG pattern matching for Lua
 ** Copyright 2007-2019, Lua.org & PUC-Rio  (see 'lpeg.html' for license)
 ** written by Roberto Ierusalimschy
 */
 
-#if !defined(lptypes_h)
-#define lptypes_h
+#if !defined(lpltypes_h)
+#define lpltypes_h
 
 
 #include <assert.h>

--- a/lplvm.c
+++ b/lplvm.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lpvm.c $
+** $Id: lplvm.c $
 ** Copyright 2007, Lua.org & PUC-Rio  (see 'lpeg.html' for license)
 */
 
@@ -10,10 +10,10 @@
 #include "lua.h"
 #include "lauxlib.h"
 
-#include "lpcap.h"
-#include "lptypes.h"
-#include "lpvm.h"
-#include "lpprint.h"
+#include "lplcap.h"
+#include "lpltypes.h"
+#include "lplvm.h"
+#include "lplprint.h"
 
 
 /* initial size for call/backtrack stack */

--- a/lplvm.h
+++ b/lplvm.h
@@ -1,11 +1,11 @@
 /*
-** $Id: lpvm.h $
+** $Id: lplvm.h $
 */
 
-#if !defined(lpvm_h)
-#define lpvm_h
+#if !defined(lplvm_h)
+#define lplvm_h
 
-#include "lpcap.h"
+#include "lplcap.h"
 
 
 /* Virtual Machine's instructions */

--- a/makefile
+++ b/makefile
@@ -25,7 +25,7 @@ CWARNS = -Wall -Wextra -pedantic \
 CFLAGS = $(CWARNS) $(COPT) -std=c99 -I$(LUADIR) -fPIC
 CC = gcc
 
-FILES = lpvm.o lpcap.o lptree.o lpcode.o lpprint.o
+FILES = lplvm.o lplcap.o lpltree.o lplcode.o lplprint.o
 # For Linux
 linux:
 	make lpeglabel.so "DLLFLAGS = -shared -fPIC"
@@ -54,9 +54,9 @@ clean:
 	rm -f $(FILES) lpeglabel.so
 
 
-lpcap.o: lpcap.c lpcap.h lptypes.h
-lpcode.o: lpcode.c lptypes.h lpcode.h lptree.h lpvm.h lpcap.h
-lpprint.o: lpprint.c lptypes.h lpprint.h lptree.h lpvm.h lpcap.h
-lptree.o: lptree.c lptypes.h lpcap.h lpcode.h lptree.h lpvm.h lpprint.h
-lpvm.o: lpvm.c lpcap.h lptypes.h lpvm.h lpprint.h lptree.h
+lplcap.o: lplcap.c lplcap.h lpltypes.h
+lplcode.o: lplcode.c lpltypes.h lplcode.h lpltree.h lplvm.h lplcap.h
+lplprint.o: lplprint.c lpltypes.h lplprint.h lpltree.h lplvm.h lplcap.h
+lpltree.o: lpltree.c lpltypes.h lplcap.h lplcode.h lpltree.h lplvm.h lplprint.h
+lplvm.o: lplvm.c lplcap.h lpltypes.h lplvm.h lplprint.h lpltree.h
 


### PR DESCRIPTION
To eliminate conflicts with the original LPeg:
```
$ lua -e "require 'lpeg'; require 'lpeglabel'; for _ in (require'lxsh').lexers.lua.gmatch('1') do end"
lua: lpvm.c:347: match: Assertion `stack > getstackbase(L, ptop) && (stack - 1)->s != NULL' failed.
Aborted

$ luarocks list | grep -A 1 -E 'lpeg|lxsh'
lpeg
   1.0.2-1 (installed) - /home/u20/.luaver/luarocks/3.5.0_5.4/lib/luarocks/rocks-5.4
--
lpeglabel
   1.6.0-1 (installed) - /home/u20/.luaver/luarocks/3.5.0_5.4/lib/luarocks/rocks-5.4
--
lxsh
   0.8.6-2 (installed) - /home/u20/.luaver/luarocks/3.5.0_5.4/lib/luarocks/rocks-5.4

$ lua -v
Lua 5.4.2  Copyright (C) 1994-2020 Lua.org, PUC-Rio

$ uname -a
Linux DESKTOP-QADODD5 5.4.72-microsoft-standard-WSL2 #1 SMP Wed Oct 28 23:40:43 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux

$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 20.04.2 LTS
Release:        20.04
Codename:       focal

```