### PR TITLE
Fix calcline returning the wrong column

### DIFF
--- a/relabel.lua
+++ b/relabel.lua
@@ -285,8 +285,7 @@ end
 local function calcline (s, i)
   if i == 1 then return 1, 1 end
   local rest, line = s:sub(1,i):gsub("[^\n]*\n", "")
-  local col = #rest
-  return 1 + line, col ~= 0 and col or 1
+  return 1 + line, #rest + 1
 end
 
 


### PR DESCRIPTION
Previously, column numbers would effectively start at 0, except the first character would register as 1 so the column numbers would go e.g. `11234567`.