### PR TITLE
Proof-of-concept for clean LuaJIT build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center"><img src="https://github.com/sqmedeiros/lpeglabel/raw/master/lpeglabel-logo.png" alt="LPegLabel" width="150px"></p>
 
-## LPegLabel - Parsing Expression Grammars (with Labels) for Lua 
+## LPegLabel - Parsing Expression Grammars (with Labels) for Lua
 
 ---
 

--- a/lpltypes.h
+++ b/lpltypes.h
@@ -42,7 +42,10 @@
 #endif                          /* } */
 
 #define luaL_setfuncs(L,f,n)	luaL_register(L,NULL,f)
+
+#if !defined(luaL_newlib)
 #define luaL_newlib(L,f)	luaL_register(L,"lpeglabel",f)
+#endif
 
 typedef size_t lua_Unsigned;
 

--- a/lpltypes.h
+++ b/lpltypes.h
@@ -34,6 +34,13 @@
 
 #define lua_rawlen		lua_objlen
 
+#if defined(__GNUC__) && ((__GNUC__*100 + __GNUC_MINOR__) >= 302) && \
+    defined(__ELF__)            /* { */
+#define LUAI_FUNC       __attribute__((visibility("hidden"))) extern
+#else                           /* }{ */
+#define LUAI_FUNC       extern
+#endif                          /* } */
+
 #define luaL_setfuncs(L,f,n)	luaL_register(L,NULL,f)
 #define luaL_newlib(L,f)	luaL_register(L,"lpeglabel",f)
 

--- a/lplvm.h
+++ b/lplvm.h
@@ -5,6 +5,7 @@
 #if !defined(lplvm_h)
 #define lplvm_h
 
+#include "lpltypes.h"
 #include "lplcap.h"
 
 

--- a/makefile
+++ b/makefile
@@ -43,6 +43,10 @@ lpeglabel.so: $(FILES)
 lpeglabel.dll: $(FILES)
 	$(CC) $(DLLFLAGS) $(FILES) -o lpeglabel.dll $(LUADIR)/bin/lua53.dll
 
+liblpeglabel.a: $(FILES)
+	ar rcs $@ $^
+
+
 $(FILES): makefile
 
 test: test.lua testlabel.lua testrelabelparser.lua relabel.lua lpeglabel.so


### PR DESCRIPTION
Background: commit `988b733849c4050cbe7dea110d86c7c8eec6bf77` introduces the use of the `LUAI_FUNC` macro, which LuaJIT doesn't have.  This is a minimal/sloppy patch which adds the missing macro.

I can confirm that, with this patch, lpeglabel builds with no
errors or warnings under LuaJIT.

This also restores the static library target, I don't know whether
that was removed from lpeg or within lpeglabel but it happens to
be the target I need.

This isn't careful, or intended for merge, it merely provides the
missing macro.